### PR TITLE
Core trait refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,34 @@
 # Konig
-> *wie sagt man "blazingly fast" uf schwiizerduutsch?*
+> Oder `koenig`? Weiß ich nicht.
+A Rust-based chess engine, built to support custom implementations and chess variants. In general, it should be just as easy to implement standard chess, hex chess, or an infinite chess board with the traits and definitions in this crate.
 
-A Rust-based chess engine, built to support custom implementations and chess variants.
-
+## Top-level `TODO`s for `v0.1.0`
+- [ ] `konig::core`
+  - The essential traits and definitions for `konig`.
+  - [ ] Finalise trait definitions.
+  - [ ] Investigate: should the given traits be object-safe?
+    - This would require removing `std::ops::Index` from the supertraits of `core::board::Board`, for example.
+  - [ ] Complete and review documentation.
+- [ ] `konig::standard`
+  - An implementation of standard chess using `konig::core`.
+  - [ ] Move validation.
+  - [ ] Move processing.
+  - [ ] Display implementation.
+  - [ ] Significant testing.
+  - [ ] Complete and review documentation.
+- [ ] `konig::io`
+  - Parsing (and streaming?) for common chess formats.
+  - [ ] Implement `konig::io::fen`.
+    - [ ] Review: should `FenData.as_board` return a `StandardBoard`, or a custom `Board`?
+    - [ ] Finalise the API on `FenData`.
+    - [ ] Add significant testing from real-world datasets.
+    - [ ] Add and review documentation.
+  - [ ] Implement `konig::io::san`.
+    - [ ] Create structs and basic API.
+    - [ ] Implement parser with `nom`.
+    - [ ] Add significant testing from real-world datasets.
+    - [ ] Add and review documentation.
+  - Implementations for [EPD](https://www.chessprogramming.org/Extended_Position_Description) and [PGN](https://www.chessprogramming.org/Portable_Game_Notation) are blocked until a later time when a `konig::core::game::Game` trait is implemented (likely deferred to `v0.2.0`)
 
 ## Usage
 `TODO`, i.e., DON'T USE THIS LIBRARY YET.

--- a/src/core/board.rs
+++ b/src/core/board.rs
@@ -15,11 +15,6 @@ pub trait Board: Default + std::fmt::Debug + std::ops::Index<Self::Index> {
     type Index: Index;
     /// Represents the pieces which may be on the board.
     type Piece: Piece;
-
-    /// A simple constructor yielding the default position.
-    fn new() -> Self {
-        Self::default()
-    }
 }
 
 /// Represents a board which can validate candidate moves.
@@ -45,7 +40,10 @@ pub trait Process: Validate {
 
     /// First validates the given candidate move, and then either returns an [`IllegalMoveError`]
     /// or uses the resulting [`LegalMove`] to update the board state and returns it.
-    fn validate_and_process(&self, candidate: Self::Move) -> Result<Self, Self::ValidationError> {
+    fn validate_and_process(&self, candidate: Self::Move) -> Result<Self, Self::ValidationError>
+    where
+        Self: Sized,
+    {
         let legal_move = self.validate(candidate)?;
         Ok(self.process(legal_move))
     }

--- a/src/core/board.rs
+++ b/src/core/board.rs
@@ -1,12 +1,16 @@
-//! An abstract `Board` trait.
+//! Traits for representing chessboards.
 
 use super::index::Index;
 use super::piece::Piece;
 use super::r#move::{IllegalMoveError, LegalMove, Move};
 
 /// Represents a static view into a single board position, with
-/// no notion of moves.
-pub trait StaticBoard: Default + std::fmt::Debug + std::ops::Index<Self::Index> {
+/// no notion of moves or move legality.
+///
+/// For a notion of legality see [`Validate`].
+///
+/// For a notion of moves acting on state, see [`Process`].
+pub trait Board: Default + std::fmt::Debug + std::ops::Index<Self::Index> {
     /// Represents a specific place on the board.
     type Index: Index;
     /// Represents the pieces which may be on the board.
@@ -18,47 +22,31 @@ pub trait StaticBoard: Default + std::fmt::Debug + std::ops::Index<Self::Index> 
     }
 }
 
-/// Represents a chessboard at the highest level, as an
-/// object that can modify itself based on a legal move,
-/// and which can determine whether a given move is legal.
-pub trait Board: StaticBoard {
-    /// This error is returned if a move cannot be validated.
-    type IllegalMoveError: IllegalMoveError;
-    /// Represents a specific place on the board.
-    type Index: Index;
-    /// Represents a move on the board which is known to be legal.
-    type LegalMove: LegalMove<Board = Self>;
-    /// Represents an arbitrary move on the board, which may be illegal.
-    type Move: Move<Board = Self>;
-    /// Represents the pieces which may be on the board.
-    type Piece: Piece;
+/// Represents a board which can validate candidate moves.
+pub trait Validate: Board {
+    /// Represents a move which may or may not be legal.
+    type Move: Move;
+    /// Represents a move which has been confirmed to be legal.
+    type LegalMove: LegalMove;
+    /// The error created when move validation fails.
+    type ValidationError: IllegalMoveError;
+    /// Validates the given candidate move based on the current state of self.
+    fn validate(&self, candidate: Self::Move) -> Result<Self::LegalMove, Self::ValidationError>;
+}
 
-    /// Applies the given LegalMove, and returns the new state of the board.
-    fn process(&mut self, candidate: Self::LegalMove) -> Self;
+/// Represents a board which can process validated moves.
+pub trait Process: Validate {
+    /// Updates the board state with the given [`LegalMove`] and returns the new state.
+    ///
+    /// Note that the only valid source for the candidate move is from [`Validate`]'s
+    /// `validate` method, and in general you should prefer `validate_and_process` for
+    /// updating the board's state with a single [`Move`].
+    fn process(&self, candidate: Self::LegalMove) -> Self;
 
-    /// Tries to validate the given candidate `Move` and convert it into a `LegalMove`.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if the candidate move is illegal given the current state of the board.
-    fn validate(&self, candidate: Self::Move) -> Result<Self::LegalMove, Self::IllegalMoveError>;
-
-    /// Tries to first validate and then process the given candidate `Move`.
-    ///
-    /// # Errors
-    ///
-    /// This function will return an error if the candidate move is illegal given the current state of the board.
-    fn validate_and_process(
-        &mut self,
-        candidate: Self::Move,
-    ) -> Result<Self, Self::IllegalMoveError> {
+    /// First validates the given candidate move, and then either returns an [`IllegalMoveError`]
+    /// or uses the resulting [`LegalMove`] to update the board state and returns it.
+    fn validate_and_process(&self, candidate: Self::Move) -> Result<Self, Self::ValidationError> {
         let legal_move = self.validate(candidate)?;
         Ok(self.process(legal_move))
     }
-}
-
-// blanket impl over all boards
-impl<T: Board> StaticBoard for T {
-    type Index = <Self as Board>::Index;
-    type Piece = <Self as Board>::Piece;
 }

--- a/src/core/board.rs
+++ b/src/core/board.rs
@@ -10,7 +10,7 @@ use super::r#move::{IllegalMoveError, LegalMove, Move};
 /// For a notion of legality see [`Validate`].
 ///
 /// For a notion of moves acting on state, see [`Process`].
-pub trait Board: Default + std::fmt::Debug + std::ops::Index<Self::Index> {
+pub trait Board: std::fmt::Debug {
     /// Represents a specific place on the board.
     type Index: Index;
     /// Represents the pieces which may be on the board.

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -16,4 +16,4 @@ pub enum IndexError<T> {
 
 // TODO: are these trait bounds necessary?
 /// Represents a particular place on the associated [`Board`]
-pub trait Index: Sized + Into<usize> + TryFrom<usize> {}
+pub trait Index: Into<usize> + TryFrom<usize> {}

--- a/src/core/index.rs
+++ b/src/core/index.rs
@@ -1,6 +1,5 @@
 //! An abstract `Index` trait.
 
-use super::board::StaticBoard;
 use thiserror::Error;
 
 /// The result of the incorrect creation or usage of

--- a/src/core/move.rs
+++ b/src/core/move.rs
@@ -8,7 +8,7 @@ use super::board::Board;
 /// of a candidate move.
 pub trait IllegalMoveError: Error {
     /// The associated board on which moves can act.
-    type Board: Board<Move = Self::Move, LegalMove = Self::LegalMove>;
+    type Board: Board;
     /// The potentially illegal candidate moves.
     type Move: Move<Board = Self::Board>;
     /// The verified-legal moves.
@@ -24,9 +24,19 @@ pub trait Move {
 /// Represents a legal move on the associated [`Board`].
 pub trait LegalMove {
     /// A [`Board`] whose legal moves coincide with an implementor of this trait.
-    type Board: Board<LegalMove = Self, Move = <Self as LegalMove>::Move>;
+    type Board: Board;
     /// The corresponding [`Move`] implementation, which may or may not be illegal.
     type Move: Move<Board = <Self as LegalMove>::Board>;
+}
+
+/// Crate-internal constructor trait for [`LegalMove`]s.
+///
+/// The visibility modifier here prevents a crate consumer from
+/// constructing an invalid [`LegalMove`].
+pub(crate) trait WrapMove: LegalMove {
+    /// Directly wraps a [`Move`] with a [`LegalMove`],
+    /// without a validation step.
+    fn wrap(value: Self::Move) -> Self;
 }
 
 impl<T: LegalMove> Move for T {

--- a/src/io/fen.rs
+++ b/src/io/fen.rs
@@ -6,10 +6,7 @@ use crate::standard::piece::StandardPiece;
 use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::character::complete::{digit1, one_of, u16, u8};
-use nom::combinator::opt;
-use nom::error::{Error, ErrorKind, ParseError};
 use nom::multi::{many_m_n, separated_list1};
-use nom::sequence::pair;
 use nom::sequence::Tuple;
 use nom::{Finish, IResult};
 use thiserror::Error;
@@ -140,11 +137,12 @@ impl std::ops::Index<StandardIndex> for FenBoard {
 /// [`FenData`]'s [`TryFrom`] implementation.
 fn parse_fen_string(source: &str) -> IResult<&str, FenData> {
     // piece placement grammar
-    let digit17 = one_of::<&str, &str, nom::error::Error<_>>("1234567");
-    let white_piece = one_of("PNBRQK");
-    let black_piece = one_of("pnbrqk");
-    let piece = alt((white_piece, black_piece));
-    let rank_component = pair(opt(digit17), piece);
+    // let digit17 = one_of::<&str, &str, nom::error::Error<_>>("1234567");
+    // let white_piece = one_of("PNBRQK");
+    // let black_piece = one_of("pnbrqk");
+    // let piece = alt((white_piece, black_piece));
+    // let rank_component = pair(opt(digit17), piece);
+    // TODO: implement this with more accurate parsing
     let rank = many_m_n(1, 8, one_of("12345678pnbrqkPNBRQK"));
     let piece_placement = separated_list1(tag("/"), rank);
 

--- a/src/io/fen.rs
+++ b/src/io/fen.rs
@@ -66,7 +66,9 @@ pub struct FenData {
 
 impl Default for FenData {
     fn default() -> Self {
-        todo!()
+        parse_fen_string("rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1")
+            .unwrap()
+            .1
     }
 }
 
@@ -88,7 +90,7 @@ impl FenData {
     }
 }
 
-/// Wraps a [`FenData`] to provide an `impl [StaticBoard]`.
+/// Wraps a [`FenData`] to provide a [`Board`].
 #[derive(Debug, PartialEq, Eq)]
 pub struct FenBoard {
     data: FenData,
@@ -132,6 +134,10 @@ impl std::ops::Index<StandardIndex> for FenBoard {
     }
 }
 
+/// Entrypoint to FEN string parsing.
+///
+/// This function is made available in the public API via
+/// [`FenData`]'s [`TryFrom`] implementation.
 fn parse_fen_string(source: &str) -> IResult<&str, FenData> {
     // piece placement grammar
     let digit17 = one_of::<&str, &str, nom::error::Error<_>>("1234567");
@@ -334,7 +340,7 @@ mod tests {
     use super::*;
 
     #[test]
-    fn check_fen_parser_and_fail() {
+    fn check_fen_parser_on_initial_position() {
         let start = "rnbqkbnr/pppppppp/8/8/8/8/PPPPPPPP/RNBQKBNR w KQkq - 0 1";
         let (_, data) = parse_fen_string(start).unwrap();
         let default = StandardBoard::default();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,7 +2,6 @@
 //! for chess, both the standard game and some related variants.
 
 #![warn(missing_docs)]
-#![feature(type_name_of_val)]
 
 pub mod core;
 pub mod io;

--- a/src/standard/board.rs
+++ b/src/standard/board.rs
@@ -6,19 +6,20 @@ use super::{
 };
 
 use crate::{
-    core::{
-        board::{Board, Process, Validate},
-        r#move::LegalMove,
-    },
+    core::board::{Board, Process, Validate},
     standard::piece::StandardPiece,
 };
 
 /// Represents the possible castling permissions described by a FEN string.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub struct StandardCastlingPermissions {
+    /// Whether or not castling on the bottom-right is allowed.
     pub white_king_side: bool,
+    /// Whether or not castling on the bottom-left is allowed.
     pub white_queen_side: bool,
+    /// Whether or not castling on the top-right is allowed.
     pub black_king_side: bool,
+    /// Whether or not castling on the top-left is allowed.
     pub black_queen_side: bool,
 }
 

--- a/src/standard/board.rs
+++ b/src/standard/board.rs
@@ -5,7 +5,13 @@ use super::{
     r#move::{IllegalStandardMoveError, LegalStandardMove, StandardMove},
 };
 
-use crate::{core::board::Board, standard::piece::StandardPiece};
+use crate::{
+    core::{
+        board::{Board, Process, Validate},
+        r#move::LegalMove,
+    },
+    standard::piece::StandardPiece,
+};
 
 /// Represents the possible castling permissions described by a FEN string.
 #[derive(Debug, PartialEq, Eq, Clone, Copy)]
@@ -68,17 +74,22 @@ pub struct StandardBoard {
 }
 
 impl Board for StandardBoard {
-    type IllegalMoveError = IllegalStandardMoveError;
     type Index = StandardIndex;
+    type Piece = StandardPiece;
+}
+
+impl Validate for StandardBoard {
     type LegalMove = LegalStandardMove;
     type Move = StandardMove;
-    type Piece = StandardPiece;
+    type ValidationError = IllegalStandardMoveError;
 
-    fn process(&mut self, candidate: Self::LegalMove) -> Self {
+    fn validate(&self, candidate: Self::Move) -> Result<Self::LegalMove, Self::ValidationError> {
         todo!()
     }
+}
 
-    fn validate(&self, candidate: Self::Move) -> Result<Self::LegalMove, Self::IllegalMoveError> {
+impl Process for StandardBoard {
+    fn process(&self, candidate: Self::LegalMove) -> Self {
         todo!()
     }
 }
@@ -157,7 +168,7 @@ impl Default for StandardBoard {
     }
 }
 
-impl std::ops::Index<<Self as Board>::Index> for StandardBoard {
+impl std::ops::Index<StandardIndex> for StandardBoard {
     type Output = Option<<Self as Board>::Piece>;
 
     fn index(&self, index: <Self as Board>::Index) -> &Self::Output {

--- a/src/standard/move.rs
+++ b/src/standard/move.rs
@@ -1,5 +1,5 @@
 use super::{board::StandardBoard, index::StandardIndex};
-use crate::core::r#move::{IllegalMoveError, LegalMove, Move};
+use crate::core::r#move::{IllegalMoveError, LegalMove, Move, WrapMove};
 use thiserror::Error;
 
 /// Results when a [`StandardMove`] cannot be converted into a [`LegalStandardMove`]
@@ -26,8 +26,10 @@ impl IllegalMoveError for IllegalStandardMoveError {
 /// including illegal moves.
 #[derive(PartialEq, Eq, Clone, Copy, Debug)]
 pub struct StandardMove {
-    source: StandardIndex,
-    target: StandardIndex,
+    /// The position to take a [`Piece`] from.
+    pub source: StandardIndex,
+    /// The position to move a [`Piece`] to.
+    pub target: StandardIndex,
 }
 
 /// Represents a legal move on a `StandardBoard`.
@@ -41,6 +43,12 @@ impl Move for StandardMove {
 impl LegalMove for LegalStandardMove {
     type Board = StandardBoard;
     type Move = StandardMove;
+}
+
+impl WrapMove for LegalStandardMove {
+    fn wrap(value: Self::Move) -> Self {
+        Self(value)
+    }
 }
 
 impl From<(StandardIndex, StandardIndex)> for StandardMove {


### PR DESCRIPTION
- Minor documentation tweaks.
- Split `core::board::Board` into three traits for granularity.
- Made `core::board::Board` and new traits object-safe for flexibility by consumers.
  - This required removing `std::ops::Index` from the supertraits of `core::board::Board`, which does make sense for non-finite boards, or those with no obvious iteration order, but should there be some definition like this? 
 ```rust
  type IndexedBoard<Index> = Board<Index = Index> + std::ops::Index<Index>;
```